### PR TITLE
Fix deploy to serve from root url

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,14 @@
+name: Deploy to Staging
+
+on:
+    pull_request:
+        branches: [dev]
+
+jobs:
+    build:
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+            - run: npm ci
+            - run: npm run deploy:github
+

--- a/README.mdx
+++ b/README.mdx
@@ -6,7 +6,7 @@ This repository hosts the code for the new website of the Electric Hive, an inte
 
 ## Demo
 
--   [hive-website.vercel.app](hive-website.vercel.app)
+-   [electrichive.github.io](electrichive.github.io)
 
 ## Authors
 

--- a/README.mdx
+++ b/README.mdx
@@ -6,7 +6,7 @@ This repository hosts the code for the new website of the Electric Hive, an inte
 
 ## Demo
 
--   [electrichive.github.io](electrichive.github.io)
+-   [electrichive.github.io/staging](electrichive.github.io/staging)
 
 ## Authors
 

--- a/README.mdx
+++ b/README.mdx
@@ -8,6 +8,11 @@ This repository hosts the code for the new website of the Electric Hive, an inte
 
 -   [electrichive.github.io/staging](electrichive.github.io/staging)
 
+## Deploy to Staging
+
+The [staging site](electrichive.github.io/staging) is served from the `gh-pages` of `github.com/electrichive/hive-website`.
+To deploy from the latest updates on `dev`, run `npm run deploy:github`.
+
 ## Authors
 
 -   [@tomstrat](https://www.github.com/tomstrat)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@
 const path = require('path');
 
 module.exports = {
-    pathPrefix: "/",
+    pathPrefix: "/staging",
     siteMetadata: {
         title: 'Electric Hive',
         description: 'INSERT DESCRIPTION HERE',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,7 @@
 const path = require('path');
 
 module.exports = {
+    pathPrefix: "/",
     siteMetadata: {
         title: 'Electric Hive',
         description: 'INSERT DESCRIPTION HERE',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@
 const path = require('path');
 
 module.exports = {
-    pathPrefix: "/staging",
+    pathPrefix: "/",
     siteMetadata: {
         title: 'Electric Hive',
         description: 'INSERT DESCRIPTION HERE',

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "gatsby-plugin-root-import": "^2.0.7",
         "gatsby-plugin-styled-components": "^4.14.0",
         "gatsby-plugin-testing": "^0.3.5",
+        "gh-pages": "^5.0.0",
         "hygen": "^6.1.0",
         "jest": "^27.2.1",
         "jest-jasmine2": "^27.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "lint": "eslint **/*.{js,ts,jsx,tsx,md,mdx}",
         "new-component": "hygen component new",
         "storybook": "NODE_ENV=production start-storybook -p 6006",
-        "build-storybook": "NODE_ENV=production build-storybook"
+        "build-storybook": "NODE_ENV=production build-storybook",
+        "deploy:github": "gatsby build --prefix-paths && gh-pages -d public"
     },
     "dependencies": {
         "@mdx-js/mdx": "^1.6.22",


### PR DESCRIPTION
- feat: deploy github pages site from base url
- feat: add script for deploying to github
- feat: include gh-pages dependency
- doc: change demo site to reflect live deployment
- feat: deploy from /staging and change demo link
- doc: write instructions for deploying to github pages
- feat: run gh-pages deployment in github action
- fix: change serve path from prod repo to be base website
